### PR TITLE
containerize tsp-web

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:latest
+MAINTAINER "keller.eric@gmail.com"
+
+RUN apt-get update
+RUN apt-get install -y  --no-install-recommends task-spooler nodejs nodejs-legacy npm
+
+RUN mkdir -p /tsp
+COPY . /tsp
+
+ENV TS_SOCKET=/tsp/tsp-queue.socket
+WORKDIR /tsp
+
+RUN npm install
+EXPOSE 3000
+ENTRYPOINT ["/usr/bin/node", "index.js"]
+

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ Use the Docker file to create your image and play around with tsp-web
 1. Install Docker, following the instructions https://docs.docker.com/engine/installation/
 1. Build your docker image: `docker build -t $USER/tsp-web .`
 1. Create a container from this image: `docker run --name my-tsp-web -d $USER/tsp-web:latest`
-1. Access your container: `docker exec -ti my-tsp-web /bin/bash`
-1. Execute some tsp commands: `tsp -L OK ls && tsp -L NOK foobar && tsp -L WAIT sleep 30`
+1. Execute some tsp commands in your container: `docker exec -d my-tsp-web /bin/bash -c "tsp -L OK ls && tsp -L NOK foobar && tsp -L WAIT sleep 30"`
 1. have a look at the web interface: `firefox "$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' my-tsp-web):3000"`
 

--- a/README.md
+++ b/README.md
@@ -29,3 +29,14 @@ In order to create a Debian package you have to:
 1. add your user to the tsp group `sudo usermod -aG tsp $USER`
 1. Log out and log back in. This ensures your user is running with the correct permissions.
 
+## Try it out with docker
+
+Use the Docker file to create your image and play around with tsp-web
+
+1. Install Docker, following the instructions https://docs.docker.com/engine/installation/
+1. Build your docker image: `docker build -t $USER/tsp-web .`
+1. Create a container from this image: `docker run --name my-tsp-web -d $USER/tsp-web:latest`
+1. Access your container: `docker exec -ti my-tsp-web /bin/bash`
+1. Execute some tsp commands: `tsp -L OK ls && tsp -L NOK foobar && tsp -L WAIT sleep 30`
+1. have a look at the web interface: `firefox "$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' my-tsp-web):3000"`
+


### PR DESCRIPTION
Use Docker ubuntu:latest to containerize tsp-web application.
Update the Readme with getting started instructions