### PR TITLE
add missing build dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: tsp-web
 Section: misc
 Priority: optional
 Maintainer: Eric Keller <eric.keller.ek1@roche.com>
-Build-Depends: debhelper (>=9), npm, nodejs, dh-systemd (>= 1.5)
+Build-Depends: debhelper (>=9), npm, nodejs, nodejs-legacy, dh-systemd (>= 1.5), task-spooler
 Standards-Version: 3.9.7
 #Homepage: <insert the upstream URL, if relevant>
 Vcs-Git: ssh://git@github.com:Roche/tsp-web.git


### PR DESCRIPTION
missing build dependencies, the task-spooler package is required for executing the tests